### PR TITLE
Bug at selling Chips

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -10,18 +10,21 @@ AddEventHandler("qb-casino:sharlock:sell", function()
     local src = source
     local price = 0
     local Player = QBCore.Functions.GetPlayer(src)
-    if Player.PlayerData.items ~= nil and next(Player.PlayerData.items) ~= nil then 
+    local xItem = Player.Functions.GetItemByName("casinochips")
+    if xItem ~= nil and xItem.amount > 0 then
         for k, v in pairs(Player.PlayerData.items) do 
             if Player.PlayerData.items[k] ~= nil then 
                 if ItemList[Player.PlayerData.items[k].name] ~= nil then 
                     price = price + (ItemList[Player.PlayerData.items[k].name] * Player.PlayerData.items[k].amount)
                     Player.Functions.RemoveItem(Player.PlayerData.items[k].name, Player.PlayerData.items[k].amount, k)
+						
+		Player.Functions.AddMoney("cash", price, "sold-casino-chips")
+        	TriggerClientEvent('QBCore:Notify', src, "You sold your chips for $"..price)
+        	TriggerEvent("qb-log:server:CreateLog", "casino", "Chips", "blue", "**"..GetPlayerName(src) .. "** got $"..price.." for selling the Chips")
                 end
             end
         end
-        Player.Functions.AddMoney("cash", price, "sold-casino-chips")
-        TriggerClientEvent('QBCore:Notify', src, "You sold your chips for $"..price)
-        TriggerEvent("qb-log:server:CreateLog", "casino", "Chips", "blue", "**"..GetPlayerName(src) .. "** got $"..price.." for selling the Chips")
+        
         else
         TriggerClientEvent('QBCore:Notify', src, "You have no chips..")
     end
@@ -32,7 +35,7 @@ exports["qb-blackjack"]:SetGetChipsCallback(function(source)
     local Player = QBCore.Functions.GetPlayer(source)
     local Chips = Player.Functions.GetItemByName("casinochips")
 
-    if Player.PlayerData.items ~= nil and next(Player.PlayerData.items) ~= nil then 
+    if Chips ~= nil then 
         Chips = Chips
     end
 


### PR DESCRIPTION
When you try to sell, no matter if you have chips with you or not, system always sell chips.

Ex. If i have no chips on me, when i hit sell chips its not validating the item so, the system process and say that you sold your chips for $0, of course because i have no chips on me, so i fixed, maybe can be better but atleast for me works.